### PR TITLE
Fix GHSA-7fhm-mqm4-2wp7

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "squirrelly": "^7.7.0",
     "watch": "^1.0.2",
     "@types/d3": "^5.7.2",
-    "babel-plugin-remove-import-export": "^1.1.0"
+    "babel-plugin-remove-import-export": "^1.1.0",
+    "minimist": ">=1.2.2"
   },
   "author": "",
   "license": "ISC"


### PR DESCRIPTION
GHSA-7fhm-mqm4-2wp7
moderate severity
Vulnerable versions: < 1.2.2
Patched version: 1.2.2
There are high severity security vulnerabilities in two of ESLints dependencies:
- acorn
- minimist

The releases 1.8.3 and lower of svjsl (JSLib-npm) are vulnerable, but only if installed in a developer environment. A patch has been released (v1.8.4) which fixes these vulnerabilities.

Identifiers:

CVE-2020-7598
SNYK-JS-ACORN-559469 (does not have a CVE identifier)